### PR TITLE
Create new experiment contexts across top-level function calls using @remember

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v5.0.0
     hooks:
     -   id: check-added-large-files
     -   id: check-json
@@ -12,7 +12,7 @@ repos:
     -   id: trailing-whitespace
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
 
@@ -21,9 +21,10 @@ repos:
       - id: black
         name: black
         entry: black
+        args: ["-l", "140"]
         language: python
         types: [python]
-        additional_dependencies: [black==24.10.0]
+        additional_dependencies: [black==25.1.0]
         log_file: .black.log
         stages: [pre-commit]
 

--- a/pylintrc
+++ b/pylintrc
@@ -259,7 +259,7 @@ generated-members=
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=88
+max-line-length=140
 
 # TODO(https://github.com/PyCQA/pylint/issues/3352): Direct pylint to exempt
 # lines made too long by directives to pytype.

--- a/src/amnesis/experiment_context.py
+++ b/src/amnesis/experiment_context.py
@@ -13,6 +13,12 @@ from .utils import generate_name
 
 
 class ExperimentContext:
+    repository: Repository
+    experiment: Experiment
+
+    hyperparameters: Dict[str, any]
+    metrics: Dict[str, any]
+
     def __init__(self, model_name: str, experiment_name: str = None):
         self.repository = Repository()
 
@@ -38,8 +44,8 @@ class ExperimentContext:
 
         self.experiment.name = experiment_name
 
-        self.hyperparameters: Dict[str, any] = {}
-        self.metrics: Dict[str, any] = {}
+        self.hyperparameters = {}
+        self.metrics = {}
 
         # Create model directory
         self.model_dir = self.repository.get_amnesis_dir() / model_name

--- a/src/amnesis/experiment_context.py
+++ b/src/amnesis/experiment_context.py
@@ -3,6 +3,7 @@ import pathlib
 import shutil
 import time
 import uuid
+from copy import copy
 from typing import Dict
 
 from .experiment import Experiment
@@ -12,19 +13,11 @@ from .utils import generate_name
 
 
 class ExperimentContext:
-    repository: Repository
-    experiment: Experiment
-
-    hyperparameters: Dict[str, any]
-    metrics: Dict[str, any]
-
     def __init__(self, model_name: str, experiment_name: str = None):
         self.repository = Repository()
 
         if not self.repository.in_repository():
-            raise RuntimeError(
-                "Not in an amnesis repository. Run `amnesis init` to initialize a new repository."
-            )
+            raise RuntimeError("Not in an amnesis repository. Run `amnesis init` to initialize a new repository.")
 
         self.experiment = Experiment(
             git="self.git.head",  # TODO: get git head
@@ -45,12 +38,27 @@ class ExperimentContext:
 
         self.experiment.name = experiment_name
 
-        self.hyperparameters = {}
-        self.metrics = {}
+        self.hyperparameters: Dict[str, any] = {}
+        self.metrics: Dict[str, any] = {}
 
         # Create model directory
         self.model_dir = self.repository.get_amnesis_dir() / model_name
         self.model_dir.mkdir(parents=True, exist_ok=True)
+
+    @staticmethod
+    def copy_context_data(from_ctx):
+        """
+        Create a new Experiment context with copied hyperparameters and metrics from `from_ctx`.<br/>
+        Model is copied, <u>experiment name is not</u>. A random experiment name will be generated.
+
+        :param from_ctx: Object to copy data from. Should be an instance of ExperimentContext.
+        """
+        new_context = ExperimentContext(from_ctx.experiment.model_name)
+
+        new_context.hyperparameters = copy(from_ctx.hyperparameters)
+        new_context.metrics = copy(from_ctx.metrics)
+
+        return new_context
 
     def __enter__(self):
         self.experiment_dir = self.model_dir / self.experiment.uuid

--- a/src/amnesis/remember.py
+++ b/src/amnesis/remember.py
@@ -1,17 +1,19 @@
 import functools
 import sys
 import traceback
-from typing import List, Optional, TypedDict
 import warnings
+from copy import copy
+from typing import List, Optional, TypedDict
 
 from .experiment_context import ExperimentContext
 
-color_warning = lambda s: f"\033[93m{s}\033[0m"
+color_warning = lambda s: f"\033[93m{s}\033[0m"  # pylint: disable=unnecessary-lambda-assignment
 
 
-class capture:
+class capture:  # pylint: disable=invalid-name
     """
-    Original authors: Pietro Berkes, Andrea Maffezzoli --- https://code.activestate.com/recipes/577283-decorator-to-expose-local-variables-of-a-function-/
+    Original authors: Pietro Berkes, Andrea Maffezzoli
+    --- https://code.activestate.com/recipes/577283-decorator-to-expose-local-variables-of-a-function-/
     Capture the local variables of the decorated function
     """
 
@@ -22,7 +24,7 @@ class capture:
         self._capt_locals = None
         res = None
 
-        def tracer(frame, event, arg):
+        def tracer(frame, event, _):
             if event == "return":
                 self._capt_locals = frame.f_locals.copy()
 
@@ -48,7 +50,7 @@ class capture:
         return res, ret_locals
 
 
-class remember(ExperimentContext):
+class remember(ExperimentContext):  # pylint: disable=invalid-name
     """
     Wraps the decorated function with the Experiment context manager
     Automatically logs hyperparameters and other metrics if requested
@@ -64,18 +66,29 @@ class remember(ExperimentContext):
         hyperparams: List[str]
         metrics: List[str]
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-positional-arguments
         self,
         model_name: str,
         experiment_name: str = None,
         log: Optional[Log] = None,
         quick=False,
+        is_fn_singleton=True,
     ):
         """
-        :param model_name: name of the model
-        :param experiment_name: name of the experiment. If None, a name will be automatically generated
-        :param log: dictionary containing lists of hyperparameters and metrics to log automatically. Artefacts and other parameters must be logged manually.
-        :param quick: if True, disables automatic logging of local variables using a profiler. Enabling this flag requires you to log your metrics and other parameters manually.
+        :param model_name:      name of the model
+        :param experiment_name: name of the experiment.
+                                If None, a name will be automatically generated
+        :param log:             dictionary containing lists of hyperparameters and metrics to log automatically.
+                                Artefacts and other parameters must be logged manually.
+        :param quick:           if True, disables automatic logging of local variables using a profiler.
+                                Enabling this flag requires you to log your metrics and other parameters manually.
+        :param is_fn_singleton: if True, the decorator is only constructed once and acts as expected for decorator behavior,
+                                i.e., reuses the experiment context across multiple calls of the decorated function.<br />
+                                If False, a copy of the decorator is created for each function call, which allows for different
+                                experiment contexts to be used for a same model (different metrics, hyperparams, etc.)<br />
+                                If False, the experiment name will be ignored and a random name will be generated for each call.
+
+                                `# TODO: keep the original experiment name in the context and add a version number when creating a copy.`
         """
         super().__init__(model_name, experiment_name)
         if log and quick:
@@ -88,12 +101,13 @@ class remember(ExperimentContext):
 
         self._log = log if not quick else None
         self._exp_locals = None
+        self._fn_singleton = is_fn_singleton
 
     def __enter__(self):
         super().__enter__()
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type, exc_value, traceback):  # pylint: disable=redefined-outer-name
         self._auto_log_params()
         super().__exit__(exc_type, exc_value, traceback)
 
@@ -101,14 +115,14 @@ class remember(ExperimentContext):
 
     def _auto_log_params(self):
         if self._exp_locals:
-            for log_type, vars in self._log.items():
+            for log_type, vars in self._log.items():  # pylint: disable=redefined-builtin
                 for param in vars:
                     if not isinstance(param, str):
                         continue
 
                     try:
                         value = self._exp_locals[param]
-                    except:
+                    except:  # pylint: disable=bare-except
                         warnings.warn(color_warning(f"{log_type[:-1].capitalize()} {param} not found in the experiment. Skipping."))
                         continue
 
@@ -123,11 +137,34 @@ class remember(ExperimentContext):
     def __call__(self, func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            with self as ctx:
-                if self._log:
-                    experiment, self._exp_locals = capture(func)(ctx, *args, **kwargs)
+            # a shallow copy should do, since no metrics, artefacts, hyperparameters, etc. were logged yet... Unique IDs will be regenerated
+            instance = self if self._fn_singleton else copy(self)
+
+            with instance as ctx:
+                if instance._log:  # pylint: disable=protected-access
+                    experiment, instance._exp_locals = capture(func)(ctx, *args, **kwargs)
                     return experiment
                 else:
                     return func(ctx, *args, **kwargs)
 
         return wrapper
+
+    def __copy__(self):
+        """
+        Create a shallow copy of the remember decorator (including existing data/metrics).
+        The experiment context will have a different uuid and a randomly generated experiment name.
+        """
+        if self._fn_singleton:
+            raise RuntimeError("Cannot copy a singleton `remember` decorator. Set `remember(..., is_fn_singleton=False)` to allow copying.")
+
+        # Dummy object to generate new identifiers
+        context = ExperimentContext.copy_context_data(self)
+
+        cls = type(self)
+        cpy = cls.__new__(cls)
+        cpy.__dict__.update(self.__dict__)
+
+        # ExperimentContext unique data should be different. Metrics and artefacts will be stored in a different dir in .amnesis
+        cpy.__dict__.update(context.__dict__)
+
+        return cpy


### PR DESCRIPTION
## Encountered issue
Let's say we want to execute a function multiple times using a same model but with different data, only the last result is recorded by Amnesis. The current implementation of @remember, wraps the decorated function with a context manager <u>that is created only once at the start of the program</u>, overwriting the metrics on every function call.

**Here is a code example. The current implementation will only record the last experiment instead of all N executions.**
```
@remember(model_name=model, log={ "hyperparams": ['alpha'], "metrics": ['metric'] } )
def experiment(exp: ExperimentContext, data):
    alpha = 0.05
    metric = ... do stuff with data

if __name__ == "__main__":
    for data in all_data:  # data is an array of size N
        experiment(data)
```
**A currently working code for multiple runs would look like:**
```
if __name__ == "__main__":
    for data in all_data:  # data is an array of size N
        @remember(model_name=model, log={ "hyperparams": ['alpha'], "metrics": ['metric'] } )
        def experiment(exp: ExperimentContext, data):
            alpha = 0.05
            metric = ... do stuff with data

        experiment(data)
```
**OR**
```
if __name__ == "__main__":
    for data in all_data:  # data is an array of size N
        with ExperimentContext(model_name) as exp:
            alpha = 0.05
            metric = ... do stuff with data

            exp.log_metric(metric)
            exp.log_hyperparameter(alpha)
```

## Changes
Create a copy of the ExperimentContext on every function call (see decorator wrapper)
This requires changing the uuid of the copy, since amnesis creates a new directory per experiment.
The new behaviour can be activated by setting `is_fn_singleton=False` in the `@remember` constructor. (Default value is `True`. The reverse would make more sense, but I wanted to keep backward-compatibility.)

## Considerations
- I think these changes allow for possible multithreading with cleaner code (wouldn't have to create the context in the threaded function)
- This method creates an extra unused `remember` object
- Should I instead create a higher-level decorator, which would the manage and create `remember/ExperimentContext` objects as necessary ?
- With these changes, I override the `__copy__` default behaviour for `remember` which might cause issues in the future if the codebase grows...
- Other stuff which I forgot about....

There are multiple ways to achieve the same result, but I think that this way resulted in the least changes to the codebase and should be pretty compatible with future development... @G-Lauz  What do you think ?